### PR TITLE
Sim: Packed variants into one option

### DIFF
--- a/MD-81-set.xml
+++ b/MD-81-set.xml
@@ -3,7 +3,7 @@
 <!-- Copyright (c) 2024 Josh Davidson (Octal450) -->
 
 <PropertyList include="MD-80-main.xml">
-	
+	<primary-set type="bool">true</primary-set>
     <sim>
 		<aero>FDE/MD-81</aero>
 		<description>McDonnell Douglas MD-81 (JT8D-209)</description>

--- a/MD-82-set.xml
+++ b/MD-82-set.xml
@@ -3,7 +3,7 @@
 <!-- Copyright (c) 2024 Josh Davidson (Octal450) -->
 
 <PropertyList include="MD-80-main.xml">
-	
+	<variant-of>MD-81</variant-of>
     <sim>
 		<aero>FDE/MD-82</aero>
 		<description>McDonnell Douglas MD-82 (JT8D-217A)</description>

--- a/MD-83-set.xml
+++ b/MD-83-set.xml
@@ -3,7 +3,7 @@
 <!-- Copyright (c) 2024 Josh Davidson (Octal450) -->
 
 <PropertyList include="MD-80-main.xml">
-	
+	<variant-of>MD-81</variant-of>
     <sim>
 		<aero>FDE/MD-83</aero>
 		<description>McDonnell Douglas MD-83 (JT8D-219)</description>

--- a/MD-87-set.xml
+++ b/MD-87-set.xml
@@ -3,7 +3,7 @@
 <!-- Copyright (c) 2024 Josh Davidson (Octal450) -->
 
 <PropertyList include="MD-80-main.xml">
-	
+	<variant-of>MD-81</variant-of>
     <sim>
 		<aero>FDE/MD-87</aero>
 		<description>McDonnell Douglas MD-87 (JT8D-217C)</description> <!-- Note: -217C is a -219 operated as a -217A -->


### PR DESCRIPTION
Currently, all four variants appear as their own separate aircraft in the launcher. Now they appear as dropdown options.